### PR TITLE
Improve shop drag-and-drop and update combat tests

### DIFF
--- a/tests/combat.test.ts
+++ b/tests/combat.test.ts
@@ -2,37 +2,45 @@ import { describe, it, expect } from 'vitest';
 import { simulateRound } from '../src/engine/combat';
 import { PlayerState, UnitInstance } from '../src/engine/types';
 
-function mkUnit(name: string, atkPhys: number, hp: number): UnitInstance {
+function mkUnit(id: string, dmg: number, hp: number): UnitInstance {
   return {
-    id: name,
-    defId: name,
-    name,
-    rarity: 'COMMON' as any,
+    id,
+    defId: id,
+    name: id,
+    rarity: 'COMMON',
     level: 1,
     stars: 1,
-    stats: { hp, defPhys: 0, defMag: 0, atkPhys, atkMag: 0, atkSpeed: 1, crit: 0, critDmg: 1.5, manaMax: 100 },
-    ability: { kind: 'none', cost: 100, value: 0, desc: '' },
+    stats: { hp, dmg, critChance: 0, critMultiplier: 1.5 },
     tags: [],
     isChampion: false,
-    current: { hp, mana: 0 }
+    passives: [],
+    current: { hp }
   };
 }
 
-function mkState(id: string, actives: UnitInstance[]): PlayerState {
+function mkState(id: string, units: UnitInstance[]): PlayerState {
   return {
-    userId: id, hp: 20, xp: 0, winStreak: 0, shopLevel: 1, rerollCountThisStage: 0,
-    board: { active: [actives[0]||null, actives[1]||null, actives[2]||null], bench: [null,null,null,null], championId: '' },
-    store: [], killsThisStage: 0, drainedHPThisStage: 0, damageThisStage: 0
+    userId: id,
+    hp: 20,
+    xp: 0,
+    winStreak: 0,
+    shopLevel: 1,
+    rerollCountThisStage: 0,
+    board: { active: [units[0] || null, units[1] || null, units[2] || null], bench: [null, null, null, null], championId: '' },
+    store: [],
+    killsThisStage: 0,
+    drainedHPThisStage: 0,
+    damageThisStage: 0
   };
 }
 
 describe('Combat basics', () => {
   it('ends when one side has no actives; damage = base + remaining', () => {
-    const p1 = mkState('P1', [mkUnit('A', 10, 1), null as any, null as any]);
-    const p2 = mkState('P2', [mkUnit('B', 1, 100), null as any, null as any]);
+    const p1 = mkState('P1', [mkUnit('A', 10, 1)]);
+    const p2 = mkState('P2', [mkUnit('B', 1, 100)]);
     const res = simulateRound(p1, p2, 1);
     expect(res.winner).toBe(2);
-    expect(res.damageToP1).toBeGreaterThan(0);
+    expect(res.damageToP1).toBe(2);
     expect(res.damageToP2).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- Fix shop bench layout and add dedicated drop zones with row labels
- Update drag manager to accept/return drop success and prevent snap-back when accepted
- Refresh combat unit test for new hp/dmg stat model

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c74cc685bc8322842de4f007193c91